### PR TITLE
Check that /etc/shadow is actually not readable

### DIFF
--- a/core/text-test.c
+++ b/core/text-test.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
 		txt = text_load("/");
 		ok(txt == NULL && errno == EISDIR, "Opening directory");
 
-		if (access("/etc/shadow", F_OK) == 0) {
+		if (access("/etc/shadow", F_OK) == 0 && access("/etc/shadow", R_OK) != 0) {
 			txt = text_load("/etc/shadow");
 			ok(txt == NULL && errno == EACCES, "Opening file without sufficient permissions");
 		}


### PR DESCRIPTION
In some chrooted build enviroments the build/test process runs with
UID=0. In these cases the "Opening file without sufficient permissions"
test fails, as /etc/shadow is readable. Let's perform it only if it
is actually not readable.