### PR TITLE
vis: allow tests to have an optional lua script

### DIFF
--- a/vis/visrc.lua
+++ b/vis/visrc.lua
@@ -1,12 +1,21 @@
 package.path = '../../lua/?.lua;'..package.path
 dofile("../../lua/vis.lua")
 
+local function run_if_exists(luafile)
+	local f = io.open(luafile, "r")
+	if f ~= nil then
+		f:close()
+		dofile(luafile)
+	end
+end
+
 vis.events.subscribe(vis.events.WIN_OPEN, function(win)
 	-- test.in file passed to vis
 	local name = win.file.name
 	if name then
 		-- use the corresponding test.lua file
 		name = string.gsub(name, '%.in$', '')
+		run_if_exists(string.format("%s.lua", name))
 		local file = io.open(string.format("%s.keys", name))
 		local keys = file:read('*all')
 		keys = string.gsub(keys, '%s*\n', '')


### PR DESCRIPTION
The script named after <test-name>.lua, if exists, is run
just before loading and executing <test-name>.keys.

This allows tests to inject Lua code in the running vis instance
to help augment the test environment. For instance, a test could
listen to vis.events.FILE_SAVE_PRE events and mutate file text.

Need this to add a couple tests for https://github.com/martanne/vis/pull/809.
The actual tests are in https://github.com/martanne/vis-test/pull/19.