### PR TITLE
core/Makefile: Respect $CC and $CFLAGS

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -12,7 +12,7 @@ test: $(ALL)
 
 config.h:
 	@echo Generating ccan configuration header
-	@${CC} ccan-config.c -o ccan-config && ./ccan-config > config.h
+	@${CC} ccan-config.c -o ccan-config && ./ccan-config "${CC}" ${CFLAGS} > config.h
 
 text-test: config.h text-test.c ../../text.c ../../text-util.c ../../text-motions.c ../../text-objects.c ../../text-regex.c
 	@echo Compiling $@ binary


### PR DESCRIPTION
Related: https://bugs.gentoo.org/722014